### PR TITLE
Fix - no table ready while installing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. This project adhere to the [Semantic Versioning](http://semver.org/) standard.
 
+## [0.2.1] 2026-02-03
+
+* Fix - Prevent table readiness checks while WordPress is installing.
+
 ## [0.2.0] 2026-01-05
 
 * Version - Update minimum required version of the stellarwp/schema library to v3.2.0.

--- a/src/Tables/Provider.php
+++ b/src/Tables/Provider.php
@@ -57,6 +57,14 @@ class Provider extends Provider_Abstract {
 				Register::table( Task_Logs::class );
 			}
 
+			/*
+			 * During WordPress installation, database operations are deferred.
+			 * Don't signal table readiness until installation is complete.
+			 */
+			if ( wp_installing() ) {
+				return;
+			}
+
 			/**
 			 * Fires an action when the Shepherd tables are registered.
 			 *

--- a/tests/wpunit/Tables/Tables_Provider_Test.php
+++ b/tests/wpunit/Tables/Tables_Provider_Test.php
@@ -33,6 +33,27 @@ class Tables_Provider_Test extends WPTestCase {
 	/**
 	 * @test
 	 */
+	public function it_should_not_fire_tables_registered_action_when_wp_installing(): void {
+		// Mock wp_installing() to return true
+		$this->set_fn_return( 'wp_installing', true );
+
+		$hook_fired = false;
+		$prefix = Config::get_hook_prefix();
+
+		add_action( "shepherd_{$prefix}_tables_registered", function() use ( &$hook_fired ) {
+			$hook_fired = true;
+		} );
+
+		// Re-register to trigger the action
+		$provider = new Provider( Config::get_container() );
+		$provider->register();
+
+		$this->assertFalse( $hook_fired, 'The tables_registered action should NOT be fired when wp_installing() returns true' );
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_should_fire_error_action_on_database_exception(): void {
 		$error_hook_fired = false;
 		$registered_hook_fired = false;


### PR DESCRIPTION
During WordPress installation, database operations are deferred by the Schema library's Builder::up() method.
This fix ensures the shepherd_{prefix}_tables_registered action is not fired when wp_installing() returns true, preventing downstream code from attempting to use tables that don't exist yet.

This comes in the context of [this CI failure](https://github.com/the-events-calendar/event-tickets-plus/actions/runs/21636876362/job/62364833061?pr=2026#step:23:20).


